### PR TITLE
VOL-223: Refactor of logic around project contact widgets.

### DIFF
--- a/CRM/Volunteer/BAO/ProjectContact.php
+++ b/CRM/Volunteer/BAO/ProjectContact.php
@@ -37,4 +37,30 @@ class CRM_Volunteer_BAO_ProjectContact extends CRM_Volunteer_DAO_ProjectContact 
 
   const RELATIONSHIP_OPTION_GROUP = 'volunteer_project_relationship';
 
+  /**
+   * Helper function to determine whether or not the current user can read a
+   * given contact.
+   *
+   * @param mixed $contactId
+   *   Int or int-like string representing the contact ID.
+   * @return boolean
+   */
+  static function contactIsReadable($contactId) {
+    $contactIsReadable = TRUE;
+    try {
+      // Getlist fails given an IN param for id, so one at a time it is.
+      $getList = civicrm_api3("Contact", "getlist", array(
+        "id" => $contactId,
+        "check_permissions" => 1
+      ));
+      if ($getList['count'] == 0) {
+        $contactIsReadable = FALSE;
+      }
+    }
+    catch (Exception $e) {
+      $contactIsReadable = FALSE;
+    }
+    return $contactIsReadable;
+  }
+
 }

--- a/ang/volunteer/Project.html
+++ b/ang/volunteer/Project.html
@@ -116,11 +116,11 @@
       <legend>{{ts("Relationships")}}</legend>
 
       <div ng-repeat="relType in relationship_types">
-        <div ng-if="editContactType[relType.value]" crm-ui-field="{name: projectForm[relType.name], title: ts(relType.label)}" ng-class="'crm-vol-rel-' + relType.name">
+        <div ng-if="showRelationshipType[relType.value]" crm-ui-field="{name: projectForm[relType.name], title: ts(relType.label)}" ng-class="'crm-vol-rel-' + relType.name">
           <input crm-ui-id="projectForm[relType.name]" crm-entityref="{entity: 'Contact', select: {allowClear:true, multiple: true}}" ng-model="relationships[relType.value]" />
           <div class="description" ng-show="relType.description">{{relType.description}}</div>
         </div>
-        <div ng-if="!editContactType[relType.value]">
+        <div ng-if="!showRelationshipType[relType.value]">
           <input crm-ui-id="projectForm[relType.name]" type="hidden" ng-model="relationships[relType.value]" />
         </div>
       </div>

--- a/ang/volunteer/Project.js
+++ b/ang/volunteer/Project.js
@@ -53,16 +53,6 @@
           },
           profile_status: function(crmProfiles) {
             return crmProfiles.load();
-          },
-          //VOL-223: Used for determining visibility of each contact type widget
-          can_edit_contact_types: function(crmApi, $route) {
-            if ($route.current.params.projectId == 0) {
-              return false;
-            } else {
-              return crmApi('VolunteerProject', 'getcaneditcontacts', {
-                id: $route.current.params.projectId
-              });
-            }
           }
         }
       });
@@ -70,18 +60,19 @@
   );
 
 
-  angular.module('volunteer').controller('VolunteerProject', function($scope, $location, $q, $route, crmApi, crmUiAlert, crmUiHelp, countries, project, profile_status, campaigns, relationship_data, supporting_data, location_blocks, volBackbone, can_edit_contact_types) {
+  angular.module('volunteer').controller('VolunteerProject', function($scope, $location, $q, $route, crmApi, crmUiAlert, crmUiHelp, countries, project, profile_status, campaigns, relationship_data, supporting_data, location_blocks, volBackbone) {
     // The ts() and hs() functions help load strings for this module.
     var ts = $scope.ts = CRM.ts('org.civicrm.volunteer');
     var hs = $scope.hs = crmUiHelp({file: 'CRM/Volunteer/Form/Volunteer'}); // See: templates/CRM/volunteer/Project.hlp
 
+    var volRelData = {};
     var relationships = {};
+    var showRelationshipType = {};
     if(project.id == 0) {
       //Cloning these two objects so that their original values aren't subject to data-binding
       project = _.extend(_.clone(supporting_data.values.defaults), project);
-      relationships = _.clone(supporting_data.values.defaults.relationships);
+      volRelData = _.clone(supporting_data.values.defaults.relationships);
 
-      var originalRelationships = {};
       if (CRM.vars['org.civicrm.volunteer'].entityTable) {
         project.entity_table = CRM.vars['org.civicrm.volunteer'].entityTable;
         project.entity_id = CRM.vars['org.civicrm.volunteer'].entityId;
@@ -91,20 +82,29 @@
       if (CRM.vars['org.civicrm.volunteer'].entityTitle) {
         project.title = CRM.vars['org.civicrm.volunteer'].entityTitle;
       }
-      //VOL-223
-      $scope.editContactType = supporting_data.values.canEditContacts;
     } else {
-      //VOL-223
-      $scope.editContactType = can_edit_contact_types.values;
       $(relationship_data.values).each(function (index, relationship) {
-        if (!relationships.hasOwnProperty(relationship.relationship_type_id)) {
-          relationships[relationship.relationship_type_id] = [];
+        if (!volRelData.hasOwnProperty(relationship.relationship_type_id)) {
+          volRelData[relationship.relationship_type_id] = [];
         }
-        relationships[relationship.relationship_type_id].push(relationship.contact_id);
+        volRelData[relationship.relationship_type_id].push({
+          contact_id: relationship.contact_id,
+          can_be_read_by_current_user: relationship.can_be_read_by_current_user
+        });
       });
-      var originalRelationships = _.clone(relationships);
     }
+
+    // flatten the data a bit to make it easier to work with in the template
+    _.each(volRelData, function (contacts, relTypeId) {
+      relationships[relTypeId] = [];
+      showRelationshipType[relTypeId] = false;
+      _.each(contacts, function (contact) {
+        relationships[relTypeId].push(contact.contact_id);
+        showRelationshipType[relTypeId] = showRelationshipType[relTypeId] || contact.can_be_read_by_current_user;
+      });
+    });
     project.project_contacts = relationships;
+    $scope.showRelationshipType = showRelationshipType;
 
     if (CRM.vars['org.civicrm.volunteer'] && CRM.vars['org.civicrm.volunteer'].context) {
       $scope.formContext = CRM.vars['org.civicrm.volunteer'].context;
@@ -156,8 +156,8 @@
     $scope.project = project;
     $scope.profiles = $scope.project.profiles;
     $scope.relationships = $scope.project.project_contacts;
-    //VOL-223: Used to determine visibility of relationship block
-    $scope.showRelationshipBlock = _.reduce($scope.editContactType, function(a, b) {return (a || b); });
+    // VOL-223: Used to determine visibility of relationship block
+    $scope.showRelationshipBlock = _.reduce($scope.showRelationshipType, function(a, b) {return (a || b); });
 
     $scope.refreshLocBlock = function() {
       if (!!$scope.project.loc_block_id) {

--- a/api/v3/VolunteerProject.php
+++ b/api/v3/VolunteerProject.php
@@ -221,7 +221,6 @@ function civicrm_api3_volunteer_project_removeprofile($params) {
  * Instead of the null values returned when using a crmEntityref
  * connected to the locBlock entity
  *
- *
  * @param $params
  * @return array
  *
@@ -339,39 +338,4 @@ function civicrm_api3_volunteer_project_savelocblock($params) {
 
   return civicrm_api3_create_success($location['id'], "VolunteerProject", "SaveLocBlock", $params);
 
-}
-
-
-function _civicrm_api3_volunteer_project_getcaneditcontacts_spec(&$params) {
-  $params['id']['api.required'] = 1;
-}
-
-/**
- * This function is used to determine if a user has the ability to
- * edit the contacts associated with this project.
- *
- * see: VOL-223
- *
- * @param $params
- */
-function civicrm_api3_volunteer_project_getCanEditContacts($params) {
-  $result = civicrm_api3("VolunteerProjectContact", "get", array("project_id" => $params['id']));
-
-  $types = array();
-  foreach($result['values'] as $contact) {
-    $canEdit = true;
-    try {
-      //Get list can't take an IN param for id. It fails. so one at a time it is.
-      $getList = civicrm_api3("Contact", "getlist", array("id" => $contact['contact_id'], "check_permissions" => 1));
-      if ($getList['count'] == 0) {
-        $canEdit = false;
-      }
-    } catch (Exception $e) {
-      $canEdit = false;
-    }
-    $type = $contact['relationship_type_id'];
-    $types[$type] = (array_key_exists($type, $types)) ? ($types[$type] && $canEdit) : $canEdit;
-  }
-
-  return civicrm_api3_create_success($types, "VolunteerProject", "getCanEditContacts", $params);
 }

--- a/api/v3/VolunteerProjectContact.php
+++ b/api/v3/VolunteerProjectContact.php
@@ -108,6 +108,7 @@ function civicrm_api3_volunteer_project_contact_get($params) {
 
         $projectContact['relationship_type_label'] = $optionValue['label'];
         $projectContact['relationship_type_name'] = $optionValue['name'];
+        $projectContact['can_be_read_by_current_user'] = CRM_Volunteer_BAO_ProjectContact::contactIsReadable($projectContact['contact_id']);
       }
     }
   }

--- a/api/v3/VolunteerUtil.php
+++ b/api/v3/VolunteerUtil.php
@@ -153,26 +153,6 @@ function civicrm_api3_volunteer_util_getsupportingdata($params) {
     //Allow other extensions to modify the defaults
     CRM_Volunteer_Hook::projectDefaultSettings($defaults);
 
-    //VOL-223: Make sure the logged in user has access to Contact:getlist
-    //before adding the Select2 Contact reference widgets
-    $canEditContactTypes = array();
-    foreach($defaults['relationships'] as $type => $contacts) {
-      $canEdit = true;
-      foreach($contacts as $contact) {
-        try {
-          //Get list can't take an IN param for id. It fails. so one at a time it is.
-          $getList = civicrm_api3("Contact", "getlist", array("id" => $contact, "check_permissions" => 1));
-          if ($getList['count'] == 0) {
-            $canEdit = false;
-          }
-        } catch (Exception $e) {
-          $canEdit = false;
-        }
-      }
-      $canEditContactTypes[$type] = $canEdit;
-    }
-    $results['canEditContacts'] = $canEditContactTypes;
-
     $results['defaults'] = $defaults;
   }
 
@@ -208,8 +188,8 @@ function _volunteerGetProjectRelationshipDefaults() {
 
   $contactId = CRM_Core_Session::getLoggedInContactID();
 
-  $defaults[$ownerType] = array($contactId);
-  $defaults[$managerType] = array($contactId);
+  $defaults[$ownerType] = array('contact_id' => $contactId);
+  $defaults[$managerType] = array('contact_id' => $contactId);
 
   $employerRelationshipTypeId = civicrm_api3('RelationshipType', 'getvalue', array(
     'return' => "id",
@@ -223,12 +203,19 @@ function _volunteerGetProjectRelationshipDefaults() {
       'relationship_type_id' => $employerRelationshipTypeId,
       'is_active' => 1,
     ));
-    $defaultBeneficiary = array($result);
+    $defaultBeneficiary = array('contact_id' => $result);
   } catch(Exception $e) {
     $domain = civicrm_api3('Domain', 'getsingle', array('current_domain' => 1));
-    $defaultBeneficiary = array($domain['contact_id']);
+    $defaultBeneficiary = array('contact_id' => $domain['contact_id']);
   }
   $defaults[$beneficiaryType] = $defaultBeneficiary;
+
+  foreach ($defaults as $type => $default) {
+    $defaults[$type]['can_be_read_by_current_user'] = CRM_Volunteer_BAO_ProjectContact::contactIsReadable($default['contact_id']);
+    // to match the format of existing projects, for which each relationship type
+    // could have more than one contact, wrap each relationship in an array
+    $defaults[$type] = array($defaults[$type]);
+  }
 
   return $defaults;
 }


### PR DESCRIPTION
- Changed confusing variable names which suggested we were checking whether the contact
  in question could be edited (rather than simply read).
- Encapsulated repeated code into CRM_Volunteer_BAO_ProjectContact::contactIsReadable()
- Removed new API, which was feeling a bit like bloat, and incorporated readable/showable
  logic into existing APIs.
